### PR TITLE
Adding mergify rules to repo

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,22 @@
+pull_request_rules:
+  - name: Merge approved and green PRs with `merge when green` label
+    conditions:
+      - "#approved-reviews-by>=1"
+      - status-success=test
+      - base=main
+      - label=merge when green
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        commit_message: title+body
+  - name: Automatic merge for Dependabot pull requests
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+      - status-success=test
+      - base=main
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        commit_message: title+body

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,7 +13,7 @@ pull_request_rules:
   - name: Automatic merge for Dependabot pull requests
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
-      - status-success=test
+      - status-success=build
       - base=main
     actions:
       merge:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: Merge approved and green PRs with `merge when green` label
     conditions:
       - "#approved-reviews-by>=1"
-      - status-success=test
+      - status-success=build
       - base=main
       - label=merge when green
     actions:


### PR DESCRIPTION
This PR adds a Mergify rules to the oba-contracts so that we can use merge when green feature. It also automatically merges successful dependabot PRs.

Test Plan
 I will test it once dev-ops will have enabled it 😄