### PR TITLE
Adding the orderbook model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ethcontract",
+ "parking_lot",
  "rustc-hex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0", features = ["derive"] }
 rustc-hex = "2.1.0"
 anyhow = "1.0.32"
 serde_json = "1.0.57"
+parking_lot = "0.11.0"

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,4 @@
+pub mod orderbook;
 pub mod orders;
-
+pub use orderbook::OrderBook;
 pub use orders::Order;

--- a/src/models/orderbook.rs
+++ b/src/models/orderbook.rs
@@ -65,7 +65,7 @@ impl OrderBook {
         let mut current_orderbook = self.orders.write();
         let layer_hash_map = current_orderbook.entry(order.sell_token).or_default();
         let orders = layer_hash_map.entry(order.buy_token).or_default();
-        let search_result = orders.binary_search(&order.clone());
+        let search_result = orders.binary_search(&order);
         let pos = match search_result {
             Err(_) => return false, // order is not in orderbook
             Ok(e) => e,

--- a/src/models/orderbook.rs
+++ b/src/models/orderbook.rs
@@ -1,0 +1,128 @@
+use crate::models::Order;
+use anyhow::Result;
+use ethcontract::web3::types::Address;
+use parking_lot::RwLock;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub type OrderBookHashMap = HashMap<Address, HashMap<Address, Vec<Order>>>;
+
+#[derive(Clone, Deserialize)]
+pub struct OrderBook {
+    #[serde(with = "arc_rwlock_serde")]
+    pub orders: Arc<RwLock<OrderBookHashMap>>,
+}
+
+mod arc_rwlock_serde {
+    use parking_lot::RwLock;
+    use serde::de::Deserializer;
+    use serde::Deserialize;
+    use std::sync::Arc;
+
+    pub fn deserialize<'de, D, T>(d: D) -> Result<Arc<RwLock<T>>, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: Deserialize<'de>,
+    {
+        Ok(Arc::new(RwLock::new(T::deserialize(d)?)))
+    }
+}
+
+impl OrderBook {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        OrderBook {
+            orders: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+    #[allow(dead_code)]
+    pub fn add_order(&mut self, order: Order) -> bool {
+        let mut current_orderbook = self.orders.write();
+        let layer_hash_map = current_orderbook.entry(order.sell_token).or_default();
+        let orders = layer_hash_map.entry(order.buy_token).or_default();
+        let search_result = orders.binary_search(&order.clone());
+        let pos = match search_result {
+            Err(e) => e,
+            Ok(_) => return false, // order is already existing
+        };
+        orders.insert(pos, order.clone());
+        true
+    }
+    #[allow(dead_code)]
+    pub fn get_orders_for_tokens(self, token_1: Address, token_2: Address) -> Result<Vec<Order>> {
+        let current_orderbook = self.orders.read();
+        let empty_hash_vec: Vec<Order> = Vec::new();
+        let empty_hash_map: HashMap<Address, Vec<Order>> = HashMap::new();
+        let new_hash_map = current_orderbook.get(&token_1).unwrap_or(&empty_hash_map);
+        Ok(new_hash_map
+            .get(&token_2)
+            .unwrap_or(&empty_hash_vec)
+            .clone())
+    }
+    #[allow(dead_code)]
+    pub fn remove_order(&mut self, order: Order) -> bool {
+        let mut current_orderbook = self.orders.write();
+        let layer_hash_map = current_orderbook.entry(order.sell_token).or_default();
+        let orders = layer_hash_map.entry(order.buy_token).or_default();
+        let search_result = orders.binary_search(&order.clone());
+        let pos = match search_result {
+            Err(_) => return false, // order is not in orderbook
+            Ok(e) => e,
+        };
+        orders.remove(pos);
+        true
+    }
+}
+
+#[cfg(test)]
+pub mod test_util {
+    use super::*;
+    use ethcontract::web3::types::U256;
+
+    #[test]
+    fn test_simple_adding_order() {
+        let mut orderbook = OrderBook::new();
+        let order = Order::new_valid_test_order();
+        orderbook.add_order(order.clone());
+        let mut order_2 = Order::new_valid_test_order();
+        order_2.sell_amount = order_2.sell_amount + U256::one();
+        orderbook.add_order(order_2.clone());
+
+        assert_eq!(
+            (orderbook.get_orders_for_tokens(order.sell_token, order.buy_token)).unwrap(),
+            vec![order, order_2]
+        );
+    }
+    #[test]
+    fn test_simple_removing_order() {
+        let mut orderbook = OrderBook::new();
+        let order = Order::new_valid_test_order();
+        orderbook.add_order(order.clone());
+        let mut order_2 = Order::new_valid_test_order();
+        order_2.sell_amount = order_2.sell_amount + U256::one();
+        orderbook.add_order(order_2.clone());
+        orderbook.remove_order(order.clone());
+
+        assert_eq!(
+            vec![order_2],
+            (orderbook.get_orders_for_tokens(order.sell_token, order.buy_token)).unwrap()
+        )
+    }
+    #[test]
+    fn test_no_duplication_for_adding_order() {
+        let mut orderbook = OrderBook::new();
+        let order = Order::new_valid_test_order();
+        orderbook.add_order(order.clone());
+        let order_2 = Order::new_valid_test_order();
+        assert_eq!(orderbook.add_order(order_2), false);
+
+        assert_eq!(
+            orderbook
+                .get_orders_for_tokens(order.sell_token, order.buy_token)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+}

--- a/src/models/orderbook.rs
+++ b/src/models/orderbook.rs
@@ -57,8 +57,8 @@ impl OrderBook {
         let new_hash_map = current_orderbook.get(&token_1).unwrap_or(&empty_hash_map);
         Ok(new_hash_map
             .get(&token_2)
-            .unwrap_or(&empty_hash_vec)
-            .clone())
+            .cloned()
+            .unwrap_or(empty_hash_vec))
     }
     #[allow(dead_code)]
     pub fn remove_order(&mut self, order: Order) -> bool {


### PR DESCRIPTION
This PR prepares a new type orderbook model. It is wrapped into Arc and RwLock already, since eventually, we will need this orderbook to be shared between many async tasks (API and solution crafters).

testplan:
unit tests