### PR TITLE
Use hex macro instead of FromHex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
+name = "hex-literal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
+
+[[package]]
 name = "http"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,7 +801,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ethcontract",
- "rustc-hex",
+ "hex-literal",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ethcontract = { version = "0.8.0", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
-rustc-hex = "2.1.0"
 anyhow = "1.0.33"
+ethcontract = { version = "0.8.0", default-features = false }
+hex-literal = "0.3.1"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.58"
 tokio = { version = "0.2.4", features =["sync", "macros"] }
 warp = "0.2"

--- a/src/models/orders.rs
+++ b/src/models/orders.rs
@@ -92,7 +92,7 @@ impl PartialOrd for Order {
 #[cfg(test)]
 pub mod test_util {
     use super::*;
-    use rustc_hex::FromHex;
+    use hex_literal::hex;
 
     #[test]
     fn test_validates_valid_order() {
@@ -120,11 +120,8 @@ pub mod test_util {
     #[test]
     fn test_get_digest() {
         let order = Order::new_valid_test_order();
-
         let result = order.get_digest();
-        let expected_result = "0e9aab5c9680276d90a87387b533197feb6ac7812fb80fa49de40fcd9bee8166";
-        let expected_bytes: Vec<u8> = expected_result.from_hex().unwrap();
-
-        assert_eq!(result.to_vec(), expected_bytes);
+        let expected = hex!("0e9aab5c9680276d90a87387b533197feb6ac7812fb80fa49de40fcd9bee8166");
+        assert_eq!(result.to_vec(), expected);
     }
 }


### PR DESCRIPTION
This is better because it happens at compile time and is easier to read.

### Test Plan
The changed test passes.