### PR TITLE
Add openapi sketch for orderbook

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -18,7 +18,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Order"
+              $ref: "#/components/schemas/OrderNew"
   /api/v1/orders:
     get:
       summary: Get existing orders.
@@ -31,7 +31,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Order"
+                  $ref: "#/components/schemas/OrderFull"
   /api/v1/nonce:
     get:
       summary: The nonce to pick for a new order.
@@ -65,7 +65,8 @@ components:
     Nonce:
       description: Nonce of the batch in which the order is valid. uint32.
       type: integer
-    Order:
+    OrderNew:
+      description: Data a user provides when creating a new order.
       type: object
       properties:
         buyToken:
@@ -91,15 +92,20 @@ components:
         validTo:
           description: Time offset in seconds from epoch until which the order is valid. uint32.
           type: integer
-        signature_v:
-          description: 1 byte encoded as hex.
+        signature:
+          description: 65 bytes encoded as hex. v + r + s from the spec.
+          example: "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    OrderExtra:
+      description: Extra order data that is returned to users when querying orders but not provided by users when creating orders.
+      type: object
+      properties:
+        creationTime:
+          description: Creation time of the order. Encoded as ISO 8601 UTC.
           type: string
-          example: "0x00"
-        signature_r:
-          description: 32 bytes encoded as hex.
-          type: string
-          example: "0x0000000000000000000000000000000000000000000000000000000000000000"
-        signature_s:
-          description: 32 bytes encoded as hex.
-          type: string
-          example: "0x0000000000000000000000000000000000000000000000000000000000000000"
+          example: "2020-10-22T07:57:18Z"
+        owner:
+          $ref: "#/components/schemas/Address"
+    OrderFull:
+      allOf:
+        - $ref: "#/components/schemas/OrderNew"
+        - $ref: "#/components/schemas/OrderExtra"

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,105 @@
+openapi: 3.0.3
+info:
+  version: 0.0.1
+  title: Order Book API
+servers:
+- url: http://localhost:8080
+  description: Local
+paths:
+  /api/v1/order:
+    post:
+      summary: Create a new order.
+      responses:
+        201:
+          description: Order has been accepted.
+      requestBody:
+        description: The order to create.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Order"
+  /api/v1/orders:
+    get:
+      summary: Get existing orders.
+      # TODO: Later we could add filters through the url query to only get orders matching specific tokens etc.
+      responses:
+        200:
+          description: existing orders
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Order"
+  /api/v1/nonce:
+    get:
+      summary: The nonce to pick for a new order.
+      description: The best nonce to pick depends on how much time there is left in the current settlement according to the operator. This time is token-pair specific which is why the sell and buy tokens must be supplied.
+      parameters:
+        - name: sellToken
+          in: query
+          schema:
+            $ref: "#/components/schemas/Address"
+        - name: buyToken
+          in: query
+          schema:
+            $ref: "#/components/schemas/Address"
+      responses:
+        200:
+          description: the nonce
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Nonce"
+components:
+  schemas:
+    Address:
+      description: Ethereum 40 byte address encoded as a hex.
+      type: string
+      example: "0x6810e776880c02933d47db1b9fc05908e5386b96"
+    TokenAmount:
+      description: Amount of a token. uint112 encoded in decimal.
+      type: string
+      example: "1234567890"
+    Nonce:
+      description: Nonce of the batch in which the order is valid. uint32.
+      type: integer
+    Order:
+      type: object
+      properties:
+        buyToken:
+          $ref: "#/components/schemas/Address"
+        buyAmount:
+          $ref: "#/components/schemas/TokenAmount"
+        sellAmount:
+          $ref: "#/components/schemas/TokenAmount"
+        sellToken:
+          $ref: "#/components/schemas/Address"
+        sellTokenTip:
+          $ref: "#/components/schemas/TokenAmount"
+        orderType:
+          description: Is this a buy order or sell order?
+          type: string
+          enum: [buy, sell]
+        fillType:
+          description: Is this a fill-or-kill order a partially fillable order?
+          type: string
+          enum: [fillkill, partial]
+        nonce:
+          $ref: "#/components/schemas/Nonce"
+        validTo:
+          description: Time offset in seconds from epoch until which the order is valid. uint32.
+          type: integer
+        signature_v:
+          description: 1 byte encoded as hex.
+          type: string
+          example: "0x00"
+        signature_r:
+          description: 32 bytes encoded as hex.
+          type: string
+          example: "0x0000000000000000000000000000000000000000000000000000000000000000"
+        signature_s:
+          description: 32 bytes encoded as hex.
+          type: string
+          example: "0x0000000000000000000000000000000000000000000000000000000000000000"


### PR DESCRIPTION
This is the public api that is used by the frontend, potential other
operators, the solver.

I picked human readable encodings. token amounts are encoded as strings
because of common json library shortcomings for large integers.

You can preview the generated api documentation at https://editor.swagger.io/ .

