### PR TITLE
Update order type for current smart contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,7 +1034,6 @@ dependencies = [
  "primitive-types",
  "serde",
  "serde_json",
- "serde_with",
 ]
 
 [[package]]
@@ -1704,15 +1703,6 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f6201e064705553ece353a736a64be975680bd244908cf63e8fa71e478a51a"
-dependencies = [
  "serde",
 ]
 

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -8,7 +8,6 @@ chrono = { version = "0.4", default-features = false, features = ["serde"] }
 hex = { version = "0.4", default-features = false }
 primitive-types = { version = "0.7" }
 serde = { version = "1.0", features = ["derive"] }
-serde_with = { version = "1.6", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/model/src/h160_hexadecimal.rs
+++ b/model/src/h160_hexadecimal.rs
@@ -1,0 +1,42 @@
+use primitive_types::H160;
+use serde::{de, Deserializer, Serializer};
+use std::fmt;
+
+pub fn serialize<S>(value: &H160, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut bytes = [0u8; 20 * 2];
+    // Can only fail if the buffer size does not match but we know it is correct.
+    hex::encode_to_slice(value, &mut bytes).unwrap();
+    // Hex encoding is always valid utf8.
+    let s = std::str::from_utf8(&bytes).unwrap();
+    serializer.serialize_str(s)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<H160, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor {}
+    impl<'de> de::Visitor<'de> for Visitor {
+        type Value = H160;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "an ethereum address as a hex encoded string")
+        }
+
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let mut value = H160::zero();
+            hex::decode_to_slice(s, value.as_mut()).map_err(|err| {
+                de::Error::custom(format!("failed to decode {:?} as hex h160: {}", s, err))
+            })?;
+            Ok(value)
+        }
+    }
+
+    deserializer.deserialize_str(Visitor {})
+}

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -2,32 +2,22 @@
 //!
 //! This is in its own crate because we want to share this module between the orderbook and the solver.
 
+mod h160_hexadecimal;
+mod u256_decimal;
+
 use chrono::{offset::Utc, DateTime, NaiveDateTime};
-use primitive_types::{H160, H256};
+use primitive_types::{H160, H256, U256};
 use serde::{de, Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
-pub enum FillType {
-    FillOrKill,
-    Partial,
-}
-
-impl Default for FillType {
-    fn default() -> Self {
-        Self::FillOrKill
-    }
-}
-
-#[derive(Eq, PartialEq, Clone, Copy, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum OrderType {
+pub enum OrderKind {
     Buy,
     Sell,
 }
 
-impl Default for OrderType {
+impl Default for OrderKind {
     fn default() -> Self {
         Self::Buy
     }
@@ -44,20 +34,20 @@ pub struct Signature {
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UserOrder {
-    #[serde(with = "h160_hex")]
-    pub buy_token: H160,
-    #[serde(with = "serde_with::rust::display_fromstr")]
-    pub buy_amount: u128,
-    #[serde(with = "h160_hex")]
+    #[serde(with = "h160_hexadecimal")]
     pub sell_token: H160,
-    #[serde(with = "serde_with::rust::display_fromstr")]
-    pub sell_amount: u128,
-    #[serde(with = "serde_with::rust::display_fromstr")]
-    pub sell_token_tip: u128,
-    pub order_type: OrderType,
-    pub fill_type: FillType,
-    pub nonce: u32,
+    #[serde(with = "h160_hexadecimal")]
+    pub buy_token: H160,
+    #[serde(with = "u256_decimal")]
+    pub sell_amount: U256,
+    #[serde(with = "u256_decimal")]
+    pub buy_amount: U256,
     pub valid_to: u32,
+    pub app_data: u32,
+    #[serde(with = "u256_decimal")]
+    pub tip: U256,
+    pub order_kind: OrderKind,
+    pub partially_fillable: bool,
     pub signature: Signature,
 }
 
@@ -74,7 +64,7 @@ impl UserOrder {
 #[serde(rename_all = "camelCase")]
 pub struct Order {
     pub creation_time: DateTime<Utc>,
-    #[serde(with = "h160_hex")]
+    #[serde(with = "h160_hexadecimal")]
     pub owner: H160,
     #[serde(flatten)]
     pub user_provided: UserOrder,
@@ -139,51 +129,6 @@ impl<'de> Deserialize<'de> for Signature {
     }
 }
 
-mod h160_hex {
-    use primitive_types::H160;
-    use serde::{de, Deserializer, Serializer};
-    use std::fmt;
-
-    pub fn serialize<S>(value: &H160, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut bytes = [0u8; 20 * 2];
-        // Can only fail if the buffer size does not match but we know it is correct.
-        hex::encode_to_slice(value, &mut bytes).unwrap();
-        // Hex encoding is always valid utf8.
-        let s = std::str::from_utf8(&bytes).unwrap();
-        serializer.serialize_str(s)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<H160, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct Visitor {}
-        impl<'de> de::Visitor<'de> for Visitor {
-            type Value = H160;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                write!(formatter, "an ethereum address as a hex encoded string")
-            }
-
-            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                let mut value = H160::zero();
-                hex::decode_to_slice(s, value.as_mut()).map_err(|err| {
-                    de::Error::custom(format!("failed to decode {:?} as hex: {}", s, err))
-                })?;
-                Ok(value)
-            }
-        }
-
-        deserializer.deserialize_str(Visitor {})
-    }
-}
-
 /// Erc20 token pair specified by two contract addresses.
 #[derive(Eq, PartialEq, Copy, Clone, Debug, Hash, Ord, PartialOrd)]
 pub struct TokenPair(H160, H160);
@@ -217,32 +162,32 @@ mod tests {
     fn deserialization_and_back() {
         let value = json!(
         {
-          "owner": "0000000000000000000000000000000000000001",
           "creationTime": "1970-01-01T00:00:03Z",
-          "buyToken": "0000000000000000000000000000000000000009",
-          "buyAmount": "0",
+          "owner": "0000000000000000000000000000000000000001",
           "sellToken": "000000000000000000000000000000000000000a",
+          "buyToken": "0000000000000000000000000000000000000009",
           "sellAmount": "1",
-          "sellTokenTip": "5192296858534827628530496329220095",
-          "orderType": "buy",
-          "fillType": "fillorkill",
-          "nonce": 0,
+          "buyAmount": "0",
           "validTo": 4294967295u32,
+          "appData": 0,
+          "tip": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "orderKind": "buy",
+          "partiallyFillable": false,
           "signature": "0102000000000000000000000000000000000000000000000000000000000000030400000000000000000000000000000000000000000000000000000000000005",
         });
         let expected = Order {
             creation_time: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc),
             owner: H160::from_low_u64_be(1),
             user_provided: UserOrder {
-                buy_token: H160::from_low_u64_be(9),
-                buy_amount: 0,
                 sell_token: H160::from_low_u64_be(10),
-                sell_amount: 1,
-                sell_token_tip: 2u128.pow(112) - 1,
-                order_type: OrderType::Buy,
-                fill_type: FillType::FillOrKill,
-                nonce: 0,
+                buy_token: H160::from_low_u64_be(9),
+                sell_amount: 1.into(),
+                buy_amount: 0.into(),
                 valid_to: u32::MAX,
+                app_data: 0,
+                tip: U256::MAX,
+                order_kind: OrderKind::Buy,
+                partially_fillable: false,
                 signature: Signature {
                     v: 1,
                     r: H256::from_str(

--- a/model/src/u256_decimal.rs
+++ b/model/src/u256_decimal.rs
@@ -1,0 +1,35 @@
+use primitive_types::U256;
+use serde::{de, Deserializer, Serializer};
+use std::fmt;
+
+pub fn serialize<S>(value: &U256, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&value.to_string())
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<U256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor {}
+    impl<'de> de::Visitor<'de> for Visitor {
+        type Value = U256;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "a u256 encoded as a decimal encoded string")
+        }
+
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            U256::from_dec_str(s).map_err(|err| {
+                de::Error::custom(format!("failed to decode {:?} as decimal u256: {}", s, err))
+            })
+        }
+    }
+
+    deserializer.deserialize_str(Visitor {})
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -6,7 +6,7 @@ servers:
 - url: http://localhost:8080
   description: Local
 paths:
-  /api/v1/order:
+  /api/v1/orders:
     post:
       summary: Create a new order.
       responses:
@@ -32,26 +32,6 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/OrderFull"
-  /api/v1/nonce:
-    get:
-      summary: The nonce to pick for a new order.
-      description: The best nonce to pick depends on how much time there is left in the current settlement according to the operator. This time is token-pair specific which is why the sell and buy tokens must be supplied.
-      parameters:
-        - name: sellToken
-          in: query
-          schema:
-            $ref: "#/components/schemas/Address"
-        - name: buyToken
-          in: query
-          schema:
-            $ref: "#/components/schemas/Address"
-      responses:
-        200:
-          description: the nonce
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Nonce"
 components:
   schemas:
     Address:
@@ -59,39 +39,36 @@ components:
       type: string
       example: "6810e776880c02933d47db1b9fc05908e5386b96"
     TokenAmount:
-      description: Amount of a token. uint112 encoded in decimal.
+      description: Amount of a token. uint256 encoded in decimal.
       type: string
       example: "1234567890"
-    Nonce:
-      description: Nonce of the batch in which the order is valid. uint32.
-      type: integer
     OrderNew:
       description: Data a user provides when creating a new order.
       type: object
       properties:
-        buyToken:
-          $ref: "#/components/schemas/Address"
-        buyAmount:
-          $ref: "#/components/schemas/TokenAmount"
-        sellAmount:
-          $ref: "#/components/schemas/TokenAmount"
         sellToken:
           $ref: "#/components/schemas/Address"
-        sellTokenTip:
+        buyToken:
+          $ref: "#/components/schemas/Address"
+        sellAmount:
           $ref: "#/components/schemas/TokenAmount"
-        orderType:
-          description: Is this a buy order or sell order?
-          type: string
-          enum: [buy, sell]
-        fillType:
-          description: Is this a fill-or-kill order a partially fillable order?
-          type: string
-          enum: [fillorkill, partial]
-        nonce:
-          $ref: "#/components/schemas/Nonce"
+        buyAmount:
+          $ref: "#/components/schemas/TokenAmount"
         validTo:
           description: Time offset in seconds from epoch until which the order is valid. uint32.
           type: integer
+        appData:
+          description: Arbitrary identifier sent along with the order. Could be used to track the interface or other meta-aspects of the order. uint32.
+          type: integer
+        tip:
+          $ref: "#/components/schemas/TokenAmount"
+        orderKind:
+          description: Is this a buy order or sell order?
+          type: string
+          enum: [buy, sell]
+        partiallyFillable:
+          description: Is this a fill-or-kill order or a partially fillable order?
+          type: boolean
         signature:
           description: 65 bytes encoded as hex without `0x` prefix. v + r + s from the spec.
           example: "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"


### PR DESCRIPTION
and reorder to fields to match smart contract https://github.com/gnosis/oba-contracts/blob/main/src/contracts/libraries/GPv2Encoding.sol#L11 .

There is still discussion going on in https://github.com/gnosis/oba-services/pull/49 but we can already merge the order type and u256 serialization and come back to the error handling later.

### Test Plan
Tested with openapi and curl that order creation and retrieval works.
