### PR TITLE
Adding Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM clux/muslrust as cargo-build
+WORKDIR /usr/src/oba-services
+
+# Copy and Build Code
+COPY . .
+RUN cargo build --target x86_64-unknown-linux-musl --release
+
+# Extract Binary
+FROM alpine:latest
+
+# Handle signal handlers properly
+RUN apk add --no-cache tini
+COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/orderbook /usr/local/bin/orderbook
+COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/solver /usr/local/bin/solver
+
+CMD echo "Specify binary - either solver or orderbook"
+ENTRYPOINT ["/sbin/tini", "--"]

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -8,6 +8,6 @@ use std::sync::Arc;
 async fn main() {
     let orderbook = Arc::new(OrderBook::default());
     let filter = api::handle_all_routes(orderbook);
-    let result = warp::serve(filter).bind(([127, 0, 0, 1], 8080)).await;
+    let result = warp::serve(filter).bind(([0, 0, 0, 0], 8080)).await;
     println!("warp exited: {:?}", result);
 }


### PR DESCRIPTION
As a first step to get continuous development running. I went for using the same container for both binaries (as it's less code to maintain, faster to build on CI and I don't expect the binary to be that big in size). Looking forward to your thoughts if this is a bad idea. This decision will also affect if I have to request 1 or multiple dockerhub images

The .dockerignore/Dockerfile is mostly taken from https://github.com/gnosis/rust-template however due to having multiple workspaces the trick of compiling dependencies before copying the code doesn't work.

### Test Plan

```sh
docker build --tag gnosispm:oba-services -f docker/Dockerfile .
docker run gnosispm:oba-services solver # panics due to "not implemented"
docker run -p 8080:8080 gnosispm:oba-services orderbook
``` 

and then fetching http://localhost:8080/api/v1/orders in the browser.
